### PR TITLE
TicketFilter fix for GLPI 11

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -25,7 +25,7 @@
  * ------------------------------------------------------------------------
  *
  *  @package  	   TicketFilter
- *  @version	   1.3.0
+ *  @version	   1.4.0
  *  @author    	Chris Gralike
  *  @copyright 	Copyright (c) 2023 by Chris Gralike
  *  @license   	GPLv2+
@@ -40,7 +40,7 @@ use GlpiPlugin\Ticketfilter\Filterpattern;
 
 // Maximum GLPI version, exclusive
 // Minimal GLPI version, inclusive
-define('PLUGIN_TICKETFILTER_VERSION', '1.3.0');
+define('PLUGIN_TICKETFILTER_VERSION', '1.4.0');
 define('PLUGIN_TICKETFILTER_MIN_GLPI', '11.0.0');
 define('PLUGIN_TICKETFILTER_MAX_GLPI', '11.99.99');
 

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -105,6 +105,17 @@ class Filter {
         // Fetch patterns
         $patterns = FilterPattern::getFilterPatterns();
 
+        // Sanitization of the input to avoid Array vs String errors
+        $subject = '';
+        if (isset($item->input['name'])) {
+            if (is_string($item->input['name'])) {
+                $subject = $item->input['name'];
+            } elseif (is_array($item->input['name'])) {
+                // If an array arrives, we try to convert it to a string or take the first value
+                $subject = implode(' ', $item->input['name']);
+            }
+        }
+
         // Evaluate patterns
         if(is_array($patterns)
         && !empty($patterns)
@@ -117,7 +128,12 @@ class Filter {
                 if($Filterpattern['is_active']) {
                     // decode html_entities_encoded string from database.
                     $p = html_entity_decode($Filterpattern[FilterPattern::TICKETMATCHSTR]);
-                    if(preg_match_all("$p", $item->input['name'], $matchArray)) {
+                    
+                    // Save into a var to check it without warnings
+                    $matchResult = @preg_match_all("$p", $subject, $matchArray);
+
+                    // Enter only if there are RESULTS (> 0) and it is not FALSE
+                    if($matchResult !== false && $matchResult > 0) {
 
                         // If we found a match, use it to compose a searchstring for our sql query.
                         $searchString = (is_array($matchArray) && count($matchArray) <> 0 && array_key_exists('match', $matchArray)) ? '%'.$matchArray['match']['0'].'%' : false;
@@ -137,6 +153,7 @@ class Filter {
                                         // Keep track what tickets where matched
                                         if ( $handler->processTicket($item) ) {
                                             $itemIsMatched[$key] = 'matched';
+                                            Toolbox::logInFile(PLUGIN_NAME, "Email linked to ticket ID: " . $key . " using the pattern: " . $Filterpattern['name'] . "\n");
                                         }
                                     } // Loop.
                                 } // No matching tickets found.
@@ -144,7 +161,8 @@ class Filter {
                                 trigger_error('TicketFilter: Length of'.$searchString.' is longer then allowed by configured Ticket Match String Length', E_USER_WARNING);
                             }
                         } // No searchstring found with provided patterns.
-                    } else {
+                    } elseif ($matchResult === false) {
+                        // Only throw an error if the Regex failed (False), not if it is 0
                         trigger_error("TicketFilter: PregMatch failed! please review the pattern $p and correct it", E_USER_WARNING);
                     }
                 } // Pattern is configured inactive.

--- a/src/TicketHandler.php
+++ b/src/TicketHandler.php
@@ -211,6 +211,7 @@ class TicketHandler{
         }
         return false;
     }
+
     /**
      * processTicket(Ticket ticket) : bool -
      * Adds a followup based on the passed ticket to the loaded ticket residing in ticketHandler->ticket,
@@ -251,8 +252,7 @@ class TicketHandler{
                 // Populate Followup fields
                 $input                  = $item->input;
                 $input['items_id']      = $this->getId();
-                $input['users_id']      = false;
-                $input['users_id']      = (isset($item->input['_users_id_requester'])) ? $item->input['_users_id_requester'] : $input['users_id'];
+                $input['users_id']      = (isset($item->input['_users_id_requester'])) ? $item->input['_users_id_requester'] : ($input['users_id'] ?? 0);
                 $input['add_reopen']    = 1;
                 $input['itemtype']      = Ticket::class;
 
@@ -277,32 +277,42 @@ class TicketHandler{
             // Assess the title and solve the ticket if matched with the solved match string.
             if($this->pattern[FilterPattern::SOLVEDMATCHSTR] &&
                !empty($this->pattern[FilterPattern::SOLVEDMATCHSTR])) {
+
+                    // Sanitize name in case GLPI sends it as an array
+                    $subject = '';
+                    if (isset($item->input['name'])) {
+                        if (is_string($item->input['name'])) {
+                            $subject = $item->input['name'];
+                        } elseif (is_array($item->input['name'])) {
+                            $subject = implode(' ', $item->input['name']);
+                        }
+                    }
+
                     $p = html_entity_decode($this->pattern[FilterPattern::SOLVEDMATCHSTR]);
+
                     // Perform the search
-                    if(preg_match_all("$p", $item->input['name'], $matchArray)) {
+                    $matchResult = @preg_match_all("$p", $subject, $matchArray);
+
+                    // Only process if there is a match (> 0) and it is not an error (false)
+                    if($matchResult !== false && $matchResult > 0) {
                         // Do we have a match
                         if(is_array($matchArray) && count($matchArray) <> 0 && array_key_exists('solved', $matchArray)) {
                             if(strlen($matchArray['solved']['0']) <= $this->pattern[FilterPattern::SOLVEDMATCHSTRLEN]) {
                                 $this->addSolvedMessage($this->pattern[FilterPattern::NAME]);
                                 // Set status to solved.
                                 $this->setStatusToSolved();
-                                print "Ticket updated to solved!<br>";
+                                Toolbox::logInFile(PLUGIN_NAME, "Ticket updated to solved!\n");
+
                                 Session::addMessageAfterRedirect(__("<a href='".$this->getTicketURL()."'>New ticket was solved by the plugin!</a>"), true, INFO);
                             } else {
-                                print "Solved Patern length issue <br>";
-                                trigger_error('TicketFilter: Length of'.$matchArray['solved']['0'].' is longer then allowed by configured Ticket Match String Length', E_USER_WARNING);
+                                trigger_error('TicketFilter: Length of'.$matchArray['solved']['0'].' is longer than allowed by configured Ticket Match String Length', E_USER_WARNING);
                             }
-                        } else {// Solved pattern not found
-                            print "Patern not found <br>";
                         }
-                    } else {
-                        print "Pregmatch failed <br>";
+                    } elseif ($matchResult === false) {
+                        // Only throw an error if the Regex is malformed (Syntax Error)
                         trigger_error("TicketFilter: PregMatch failed! please review the Solved pattern $p and correct it", E_USER_WARNING);
                     }
-            } else{
-               print "No solved string found!";
             }
-            die();
             return true;
         }
         return false;


### PR DESCRIPTION
Plugin ticketfilter is not working properly in GLPI v11 due to several changes from strings to arrays.

This patch applies a sanitization process just in case an array is returned and also fixes all unwanted warnings. An output in case of match is included to check it via GLPI logs.